### PR TITLE
disk use v2

### DIFF
--- a/cloudant/cloudant.py
+++ b/cloudant/cloudant.py
@@ -120,6 +120,9 @@ class CloudantCheck(AgentCheck):
 
     def disk_use_data(self, instance, tags):
         def _stat_name(target):
+            """
+            'dimagi003 Free disk space (bytes)' -> 'free'
+            """
             tokens = target.split(' ')
             assert tokens[0] == instance['cluster']
             return tokens[1].lower()

--- a/cloudant/cloudant.py
+++ b/cloudant/cloudant.py
@@ -124,7 +124,7 @@ class CloudantCheck(AgentCheck):
             assert tokens[0] == instance['cluster']
             return tokens[1].lower()
 
-        self.get_data_for_endpoint(instance, 'disk_use', _stat_name, tags=tags)
+        self.get_data_for_endpoint(instance, 'disk_use_v2', _stat_name, tags=tags)
 
     def get_data_for_endpoint(self, instance, endpoint, stat_name_fn=None, metric_group=None, tags=None):
         url = self.MONITOR_URL_TEMPLATE.format(

--- a/cloudant/cloudant.py
+++ b/cloudant/cloudant.py
@@ -127,7 +127,7 @@ class CloudantCheck(AgentCheck):
             assert tokens[0] == instance['cluster']
             return tokens[1].lower()
 
-        self.get_data_for_endpoint(instance, 'disk_use_v2', _stat_name, tags=tags)
+        self.get_data_for_endpoint(instance, 'disk_use_v2', _stat_name, metric_group='disk_use', tags=tags)
 
     def get_data_for_endpoint(self, instance, endpoint, stat_name_fn=None, metric_group=None, tags=None):
         url = self.MONITOR_URL_TEMPLATE.format(


### PR DESCRIPTION
According to Cloudant:
"Instead of the disk_use monitoring endpoint you can use the disk_use_v2 monitoring endpoint, as that does not have the problem of the disk_use monitoring endpoint.'

@czue 
cc @emord
