### PR TITLE
Do not assume worker name is always like: celery@hostname.domain_queue

### DIFF
--- a/celery/celery.py
+++ b/celery/celery.py
@@ -102,11 +102,14 @@ class CeleryCheck(AgentCheck):
                 message='Connection to %s was successful' % url)
 
     def _split_worker_name(self, worker_name):
-        """Assumes worker name formatted as follows: celery@hostname.domain_queue
+        """Assumes worker name is formatted as follows: celery@hostname.domain_queue,
+        best effort to parse and get less verbose worker name
         """
         host_string = worker_name.split('@', 1)[1]
         hostname = host_string.split('.', 1)[0]
-        short_worker_name = host_string.split('_', 1)[1]
+        short_worker_name = host_string
+        if '_' in host_string:
+            short_worker_name = host_string.split('_', 1)[1]
         return hostname, short_worker_name
 
     def get_tasks_queued_data(self, instance, tags):


### PR DESCRIPTION
It throws the following error otherwise:

```
2017-05-21 14:57:03 UTC | ERROR | dd.collector | checks.celery(__init__.py:678) | Check 'celery' instance #0 failed
Traceback (most recent call last):
  File "/opt/datadog-agent/agent/checks/__init__.py", line 661, in run
    self.check(copy.deepcopy(instance))
  File "/etc/dd-agent/checks.d/celery.py", line 80, in check
    workers = self.get_worker_data(instance, tags)
  File "/etc/dd-agent/checks.d/celery.py", line 139, in get_worker_data
    hostname, short_worker_name = self._split_worker_name(worker_name)
  File "/etc/dd-agent/checks.d/celery.py", line 113, in _split_worker_name
    short_worker_name = host_string.split('_', 1)[1]
```