### PR TITLE
Emit datadog metric when Elasticsearch index is set to read only/allow delete

### DIFF
--- a/elasticsearch_custom/README.md
+++ b/elasticsearch_custom/README.md
@@ -1,0 +1,18 @@
+# datadog-elasticsearch-custom
+Custom metrics for Elasticsearch.
+
+## Metric list
+
+### elasticsearch.index.read_only_allow_delete
+Gauge emitted with value `1` for each index that currently has
+`index.blocks.read_only_allow_delete` set to `true`. Elasticsearch sets this
+block on an index when disk usage crosses the flood-stage watermark
+(`cluster.routing.allocation.disk.watermark.flood_stage`, default 95%). The block
+is **not** cleared automatically when disk frees up. It must be reset manually,
+and until then the index rejects writes.
+
+No datapoint is emitted for healthy indices, so absence of the metric means no
+index is blocked.
+
+### Tags
+* index: name of the affected Elasticsearch index

--- a/elasticsearch_custom/elasticsearch_custom.py
+++ b/elasticsearch_custom/elasticsearch_custom.py
@@ -1,0 +1,34 @@
+import requests
+from datadog_checks.base import AgentCheck
+
+
+class ElasticsearchCustom(AgentCheck):
+    def check(self, instance):
+        url = instance.get('url', '')
+        instance_tags = instance.get('tags', [])
+
+        with requests.Session() as session:
+            for index in _get_read_only_indices(session, url):
+                self.gauge(
+                    'elasticsearch.index.read_only_allow_delete',
+                    1,
+                    tags=instance_tags + ["index:{}".format(index)]
+                )
+
+
+def _get_read_only_indices(session, url):
+    """Return the names of indices that have the read only block set.
+
+    ES sets index.blocks.read_only_allow_delete to the string "true" on an index
+    when disk usage crosses the flood-stage watermark; the block must be cleared
+    manually. The _settings endpoint returns only indices that carry the setting.
+    """
+    endpoint = "{}/_all/_settings/index.blocks.read_only_allow_delete?flat_settings=true".format(url.rstrip("/"))
+    response = session.get(endpoint)
+    response.raise_for_status()
+    settings = response.json()
+    return [
+        index
+        for index, body in settings.items()
+        if body.get("settings", {}).get("index.blocks.read_only_allow_delete") == "true"
+    ]

--- a/elasticsearch_custom/elasticsearch_custom.yaml.example
+++ b/elasticsearch_custom/elasticsearch_custom.yaml.example
@@ -1,0 +1,6 @@
+init_config:
+
+instances:
+  - url: http://localhost:9200
+    tags:
+      - environment:staging


### PR DESCRIPTION
## Problem

When Elasticsearch disk usage reaches the flood-stage watermark (currently set to 95%), ES sets `index.blocks.read_only_allow_delete: true` on affected indices. This block is **not** cleared automatically when disk frees up. It must be reset manually, and until then the index rejects writes. We currently have no good signal for this other than pillow errors which are not monitored closely.

## Solution

A new `elasticsearch_custom` check (modeled on `couchdb_custom`, PR #25) that queries index settings and emits a per-index gauge `elasticsearch.index.read_only_allow_delete = 1`, tagged `index:<name>`, for each index that is blocked.

Nothing is emitted for healthy indices. I figured this would help keep the custom metric count lower since we only care about this signal when it's "on".

## Testing
Plan to test manually on staging which will require a related commcare-cloud PR to get the elasticsearch_custom integration onto one of the elasticsearch machines.